### PR TITLE
Add context debugging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@
 - Adaptación para control desde `.env` (`USE_LOCAL_LLM`)
     
 - Adaptación para retornar respuesta simulada (`USE_MOCK_MODE=true`) durante pruebas
+- Nueva variable `DEBUG_PRINT_CONTEXT=true` permite mostrar en consola el contexto
+  enviado al LLM para depuración
     
 
 ---

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -43,6 +43,10 @@ DATA_INDEX_PATH = Path(os.getenv("DATA_INDEX_PATH", BASE_DIR / "data" / "index")
 # Si es "false", se usará el LLM real para generar respuestas
 USE_MOCK_MODE = os.getenv("USE_MOCK_MODE", "false").lower() == "true"
 
+# Si DEBUG_PRINT_CONTEXT es "true", se imprimirá en consola el contexto recuperado
+# antes de enviarlo al LLM. Útil para depuración.
+DEBUG_PRINT_CONTEXT = os.getenv("DEBUG_PRINT_CONTEXT", "false").lower() == "true"
+
 # Ruta a los documentos para ingesta
 DOCS_INPUT_PATH = os.getenv("DOCS_INPUT_PATH", "data/raw")
 

--- a/src/rag_logic/generator.py
+++ b/src/rag_logic/generator.py
@@ -4,6 +4,7 @@ from langchain_core.documents import Document
 from src.rag_logic.retriever_module import get_retriever
 from src.rag_logic.llm_local import get_local_llm
 from src.config.gpt_profiles import GPT_PROFILES
+from src.config import settings
 from transformers import BertTokenizer
 from langchain.prompts import PromptTemplate
 
@@ -53,6 +54,13 @@ def get_rag_chain(gpt_id: str = "default", k: int = 5):
     def run_rag(question: str):
         docs = retriever.get_relevant_documents(question)
         docs = filter_docs_by_token_limit(docs, max_tokens=3000)
+
+        if settings.DEBUG_PRINT_CONTEXT:
+            print("\n[DEBUG] Contexto recuperado:")
+            for i, doc in enumerate(docs, 1):
+                print(f"\n--- Documento {i} ---")
+                print(doc.page_content)
+                print("Metadatos:", doc.metadata)
 
         return combine_chain.run({
             "input_documents": docs,


### PR DESCRIPTION
## Summary
- allow printing the retrieved context for debugging
- expose new DEBUG_PRINT_CONTEXT env variable
- document the option in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685942d14080833082462035e2a9624c