### PR TITLE
Configure OpenAI token limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@
 - Adaptación para retornar respuesta simulada (`USE_MOCK_MODE=true`) durante pruebas
 - Nueva variable `DEBUG_PRINT_CONTEXT=true` permite mostrar en consola el contexto
   enviado al LLM para depuración
+- Variables `MAX_CONTEXT_TOKENS` y `MAX_COMPLETION_TOKENS` permiten ajustar los
+  límites de tokens de contexto y respuesta al usar la API de OpenAI
     
 
 ---

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -60,3 +60,10 @@ DOCS_INPUT_PATH = os.getenv("DOCS_INPUT_PATH", "data/raw")
 # Esta ruta se usa para almacenar los fragmentos de documentos que se generarán a partir de los documentos de entrada
 # Estos chunks se usarán para la búsqueda y recuperación de información relevante
 DOCS_OUTPUT_PATH = os.getenv("DOCS_OUTPUT_PATH", "data/chunks")
+
+# Límite máximo de tokens a enviar como contexto al modelo
+MAX_CONTEXT_TOKENS = int(os.getenv("MAX_CONTEXT_TOKENS", "3000"))
+
+# Límite máximo de tokens generados por el modelo para cada respuesta
+MAX_COMPLETION_TOKENS = int(os.getenv("MAX_COMPLETION_TOKENS", "800"))
+

--- a/src/rag_logic/generator.py
+++ b/src/rag_logic/generator.py
@@ -8,7 +8,6 @@ from transformers import BertTokenizer
 from langchain.prompts import PromptTemplate
 from src.config import settings
 from src.rag_logic.llm_openai import get_openai_llm
-from src.config import settings
 
 
 # Tokenizer para estimar tamaño de contexto
@@ -17,7 +16,7 @@ tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
 def estimate_tokens(text: str) -> int:
     return len(tokenizer.encode(text, truncation=False))
 
-def filter_docs_by_token_limit(docs, max_tokens: int = 3000):
+def filter_docs_by_token_limit(docs, max_tokens: int = settings.MAX_CONTEXT_TOKENS):
     total = 0
     selected = []
     for doc in docs:
@@ -55,7 +54,7 @@ def get_rag_chain(gpt_id: str = "default", k: int = 5):
 
     def run_rag(question: str):
         docs = retriever.get_relevant_documents(question)
-        docs = filter_docs_by_token_limit(docs, max_tokens=3000)
+        docs = filter_docs_by_token_limit(docs, max_tokens=settings.MAX_CONTEXT_TOKENS)
 
         if settings.DEBUG_PRINT_CONTEXT:
             print("\n[DEBUG] Contexto recuperado:")

--- a/src/rag_logic/llm_openai.py
+++ b/src/rag_logic/llm_openai.py
@@ -6,5 +6,6 @@ def get_openai_llm():
     return ChatOpenAI(
         api_key=settings.OPENAI_API_KEY,
         model=settings.OPENAI_MODEL_NAME,
-        temperature=0.0
+        temperature=0.0,
+        max_tokens=settings.MAX_COMPLETION_TOKENS
     )


### PR DESCRIPTION
## Summary
- expose context and completion limits in settings
- apply limits in OpenAI LLM setup and RAG chain
- document new environment variables

## Testing
- `python -m py_compile src/config/settings.py src/rag_logic/generator.py src/rag_logic/llm_openai.py`

------
https://chatgpt.com/codex/tasks/task_b_685a428652c0833094d86820b0877ff3