### PR TITLE
Switch to BGE embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 - División de los documentos en chunks usando `RecursiveCharacterTextSplitter`
     
-- Uso de embeddings locales con modelo `sentence-transformers/all-MiniLM-L6-v2`
+- Uso de embeddings locales con modelo `BAAI/bge-small-en-v1.5`
     
 - Downgrade del cliente `weaviate-client` a versión 3.26.7 (por incompatibilidad con LangChain y cliente v4)
     

--- a/src/rag_logic/retriever_module.py
+++ b/src/rag_logic/retriever_module.py
@@ -18,7 +18,8 @@ def _get_weaviate_client():
 
 @lru_cache(maxsize=1)
 def _get_embedder():
-    return HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    """Return a cached embedder instance."""
+    return HuggingFaceEmbeddings(model_name="BAAI/bge-small-en-v1.5")
 
 
 def get_retriever(k: int = 5, collection_name: str = "LegalDocs"):

--- a/src/vectorstore/embedder.py
+++ b/src/vectorstore/embedder.py
@@ -10,8 +10,9 @@ from functools import lru_cache
 
 
 def get_local_embedder():
+    """Return a local embedding model."""
     return HuggingFaceEmbeddings(
-        model_name="sentence-transformers/all-MiniLM-L6-v2"
+        model_name="BAAI/bge-small-en-v1.5"
     )
 
 


### PR DESCRIPTION
## Summary
- replace MiniLM embeddings with BAAI/bge-small-en-v1.5
- update retrieval embedder code
- mention new embedding model in the docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a6880cf5083308cf3d5d9bc34c4e6