### PR TITLE
Add RETRIEVER_K setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 - Variables `MAX_CONTEXT_TOKENS` y `MAX_COMPLETION_TOKENS` permiten ajustar los
   límites de tokens de contexto y respuesta al usar la API de OpenAI
 - Se añadió autenticación por cabecera `X-API-Key` y reutilización de clientes para mejorar el rendimiento
+- Nueva variable `RETRIEVER_K` define cuántos documentos recupera el sistema por defecto
     
 
 ---

--- a/scripts/query_generator.py
+++ b/scripts/query_generator.py
@@ -12,7 +12,9 @@ warnings.filterwarnings("ignore")
 # Redirigir stderr a null para ocultar errores técnicos no críticos
 null_output = open(os.devnull, 'w')
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-NUM_K = 5  # Número de documentos a recuperar
+
+from src.config import settings
+NUM_K = settings.RETRIEVER_K  # Número de documentos a recuperar
 
 from src.rag_logic.generator import get_rag_chain
 
@@ -50,7 +52,7 @@ from src.rag_logic.generator import get_rag_chain
 
 if __name__ == "__main__":
     print("Generador RAG iniciado. (Ctrl+C para salir).")
-    chain = get_rag_chain()
+    chain = get_rag_chain(k=NUM_K)
 
     while True:
         pregunta = input("\nPregunta legal: ").strip()

--- a/scripts/query_retriever.py
+++ b/scripts/query_retriever.py
@@ -5,9 +5,10 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from src.rag_logic.retriever_module import get_retriever
+from src.config import settings
 
 if __name__ == "__main__":
-    retriever = get_retriever(k=5)
+    retriever = get_retriever(k=settings.RETRIEVER_K)
     
     query = input("Introduce tu pregunta o búsqueda: ")
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -32,7 +32,7 @@ async def query(request: QueryRequest, valid: bool = Depends(verify_api_key)):
 
     try:
         
-        chain = get_rag_chain(gpt_id=request.gpt_id, k=5)
+        chain = get_rag_chain(gpt_id=request.gpt_id, k=settings.RETRIEVER_K)
         result = await run_in_threadpool(chain, request.question)
 
         sources = [

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -86,3 +86,6 @@ MAX_CONTEXT_TOKENS = int(os.getenv("MAX_CONTEXT_TOKENS", "3000"))
 # Límite máximo de tokens generados por el modelo para cada respuesta
 MAX_COMPLETION_TOKENS = int(os.getenv("MAX_COMPLETION_TOKENS", "800"))
 
+# Número de documentos a recuperar por el retriever si no se especifica otro valor
+RETRIEVER_K = int(os.getenv("RETRIEVER_K", "5"))
+

--- a/src/rag_logic/generator.py
+++ b/src/rag_logic/generator.py
@@ -41,7 +41,7 @@ def filter_docs_by_token_limit(docs, max_tokens: int = settings.MAX_CONTEXT_TOKE
 
 
 @lru_cache(maxsize=None)
-def get_rag_chain(gpt_id: str = "default", k: int = 5):
+def get_rag_chain(gpt_id: str = "default", k: int = settings.RETRIEVER_K):
     profile = GPT_PROFILES.get(gpt_id, GPT_PROFILES["default"])
 
     # Recuperador

--- a/src/rag_logic/retriever_module.py
+++ b/src/rag_logic/retriever_module.py
@@ -22,7 +22,7 @@ def _get_embedder():
     return HuggingFaceEmbeddings(model_name="BAAI/bge-small-en-v1.5")
 
 
-def get_retriever(k: int = 5, collection_name: str = "LegalDocs"):
+def get_retriever(k: int = settings.RETRIEVER_K, collection_name: str = "LegalDocs"):
     client = _get_weaviate_client()
     embedder = _get_embedder()
 


### PR DESCRIPTION
## Summary
- add `RETRIEVER_K` environment variable in `settings.py`
- default retriever/generator/API and scripts to use this setting
- document the new environment variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685a6cdd8ea8833094c9a4f4da1d644e