### PR TITLE
Refactor RAG output format

### DIFF
--- a/scripts/query_generator.py
+++ b/scripts/query_generator.py
@@ -60,8 +60,15 @@ if __name__ == "__main__":
             break
 
         try:
-            respuesta = chain(pregunta)
+            result = chain(pregunta)
             print("\nRespuesta generada:")
-            print(respuesta)
+            print(result["result"])
+
+            print("\nFuentes utilizadas:")
+            for i, doc in enumerate(result["source_documents"], 1):
+                print(f"\n--- Documento {i} ---")
+                print(doc.page_content[:500], "...")
+                print("Metadatos:", doc.metadata)
+
         except Exception as e:
             print(f"\n[Error durante la generación]: {e}")

--- a/src/rag_logic/generator.py
+++ b/src/rag_logic/generator.py
@@ -76,9 +76,14 @@ def get_rag_chain(gpt_id: str = "default", k: int = settings.RETRIEVER_K):
                 print(doc.page_content)
                 print("Metadatos:", doc.metadata)
 
-        return combine_chain.run({
+        answer = combine_chain.run({
             "input_documents": docs,
             "question": question
         })
+
+        return {
+            "result": answer,
+            "source_documents": docs
+        }
 
     return run_rag


### PR DESCRIPTION
## Summary
- update `run_rag` to always return a dictionary with the answer and document list
- adjust the query generator script to print the new structure

## Testing
- `python -m py_compile src/rag_logic/generator.py scripts/query_generator.py src/api/main.py`
- `python scripts/query_generator.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_685b97225eb48330adbe029e0b947fc4