### PR TITLE
Add CORS middleware

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3,12 +3,24 @@ from fastapi.concurrency import run_in_threadpool
 from src.api.schemas import QueryRequest, QueryResponse, SourceDocument
 from src.rag_logic.generator import get_rag_chain
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
 import traceback
 
 from src.config import settings  # <-- importar configuración del .env
 
 app = FastAPI(title="RAG API", description="API de consulta semántica legal", version="0.1.0")
+
+# Permitir el acceso a la API desde cualquier origen para que la 
+# documentación interactiva funcione correctamente cuando se accede 
+# de forma remota.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def verify_api_key(x_api_key: str = Header(None)):


### PR DESCRIPTION
## Summary
- enable cross origin requests in the FastAPI app

## Testing
- `python -m py_compile src/api/main.py`
- `python -m uvicorn src.api.main:app --port 8000 --log-level warning --host 0.0.0.0` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_b_685ba8e56cbc83308b2651de230eb3ab