### PR TITLE
Fix USE_ONEDRIVE default logic and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@
   - `ONEDRIVE_CLIENT_ID`, `ONEDRIVE_CLIENT_SECRET`, `ONEDRIVE_TENANT_ID`
   - `ONEDRIVE_DRIVE_ID`, `ONEDRIVE_FOLDER`
   - `USE_ONEDRIVE` y `ENTRYPOINT_URL`
-- `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
+  - `USE_ONEDRIVE` es `false` por defecto; cámbialo a `true` para sincronizar documentos desde OneDrive
+  - `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
   - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento.
 
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -43,7 +43,7 @@ ONEDRIVE_DRIVE_ID = os.getenv("ONEDRIVE_DRIVE_ID")
 ONEDRIVE_FOLDER = os.getenv("ONEDRIVE_FOLDER", "")  # carpeta raíz por defecto
 
 # Habilita la descarga automática de archivos desde OneDrive
-USE_ONEDRIVE = os.getenv("USE_ONEDRIVE", "false").lower() == "false"
+USE_ONEDRIVE = os.getenv("USE_ONEDRIVE", "false").lower() == "true"
 
 # Futuro endpoint público (p.ej. URL de despliegue de la API)
 ENTRYPOINT_URL = os.getenv("ENTRYPOINT_URL")


### PR DESCRIPTION
## Summary
- correct `USE_ONEDRIVE` environment variable logic
- clarify OneDrive default behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685ceb736dec83308cef5763c17c21cb