### PR TITLE
Enable in‑memory OneDrive ingestion & connectivity test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# OpenAI API Key
+OPENAI_API_KEY=
+# Optional custom model name
+OPENAI_MODEL_NAME=gpt-4o
+
+# Weaviate connection
+WEAVIATE_URL=http://localhost:8080
+WEAVIATE_API_KEY=
+
+# Local/remote LLM configuration
+USE_LOCAL_LLM=true
+LLM_MODEL_PATH=models/mistral-7b-instruct-v0.1.Q4_K_M.gguf
+LLM_MODEL_URL=http://localhost:8001
+
+# OneDrive settings
+ONEDRIVE_PATH=onedrive
+ONEDRIVE_CLIENT_ID=
+ONEDRIVE_CLIENT_SECRET=
+ONEDRIVE_TENANT_ID=
+ONEDRIVE_DRIVE_ID=
+ONEDRIVE_FOLDER=
+USE_ONEDRIVE=false
+ENTRYPOINT_URL=
+
+# Data directories
+DATA_RAW_PATH=data/raw
+DATA_CHUNKS_PATH=data/chunks
+DATA_INDEX_PATH=data/index
+
+# Mock and debug options
+USE_MOCK_MODE=false
+DEBUG_PRINT_CONTEXT=false
+
+# API access
+API_KEY=
+
+# Ingestion options
+DOCS_INPUT_PATH=data/raw
+DOCS_OUTPUT_PATH=data/chunks
+CHUNK_SIZE=400
+CHUNK_OVERLAP=50
+MAX_CONTEXT_TOKENS=3000
+MAX_COMPLETION_TOKENS=800
+RETRIEVER_K=5

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@
   - `USE_ONEDRIVE` es `false` por defecto; cámbialo a `true` para sincronizar documentos desde OneDrive
   - `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
   - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento.
+  - Se añade un ejemplo de configuración en `*.env.example`.
+  - Nuevo script `scripts/check_onedrive.py` para verificar la conectividad listando el contenido de la ruta configurada.
 
 
 ---

--- a/scripts/check_onedrive.py
+++ b/scripts/check_onedrive.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from src.config import settings
+from src.ingestion.onedrive_client import OneDriveClient
+
+
+def main():
+    if not all([
+        settings.ONEDRIVE_CLIENT_ID,
+        settings.ONEDRIVE_CLIENT_SECRET,
+        settings.ONEDRIVE_TENANT_ID,
+        settings.ONEDRIVE_DRIVE_ID,
+    ]):
+        print("Faltan variables de entorno de OneDrive.")
+        return
+
+    try:
+        client = OneDriveClient(
+            settings.ONEDRIVE_CLIENT_ID,
+            settings.ONEDRIVE_CLIENT_SECRET,
+            settings.ONEDRIVE_TENANT_ID,
+        )
+        files = client.list_files(settings.ONEDRIVE_DRIVE_ID, settings.ONEDRIVE_FOLDER)
+    except Exception as e:
+        print(f"Error al conectar con OneDrive: {e}")
+        return
+
+    folder = settings.ONEDRIVE_FOLDER or "/"
+    print(f"Archivos en '{folder}':")
+    for item in files:
+        if "file" in item:
+            print(f"- {item['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_local_docs.py
+++ b/scripts/ingest_local_docs.py
@@ -11,6 +11,10 @@ if __name__ == "__main__":
     input_path = settings.DATA_RAW_PATH
     output_path = settings.DATA_CHUNKS_PATH
 
-    docs = process_documents(input_path, output_path)
+    docs = process_documents(
+        input_path,
+        output_path,
+        save_to_disk=not settings.USE_ONEDRIVE,
+    )
 
     print(f"\n{len(docs)} documentos procesados.")

--- a/scripts/sync_and_index.py
+++ b/scripts/sync_and_index.py
@@ -41,7 +41,11 @@ def sync_and_index(gpt_id: str):
     tracker = load_tracker()
 
     # Procesar todos los documentos disponibles
-    all_docs = process_documents(input_path, output_path)
+    all_docs = process_documents(
+        input_path,
+        output_path,
+        save_to_disk=not settings.USE_ONEDRIVE,
+    )
 
     # Filtrar aquellos que aún no se han indexado o fueron actualizados
     new_docs = []

--- a/src/ingestion/ingestor.py
+++ b/src/ingestion/ingestor.py
@@ -61,9 +61,14 @@ def compute_hash(data: bytes) -> str:
     """Devuelve un hash SHA1 del contenido para identificarlo de forma estable."""
     return hashlib.sha1(data).hexdigest()
 
-def process_documents(input_folder: Path, output_folder: Path) -> List[Dict]:
-    """Procesa documentos locales y, opcionalmente, archivos remotos de OneDrive."""
-    output_folder.mkdir(parents=True, exist_ok=True)
+def process_documents(input_folder: Path, output_folder: Path, save_to_disk: bool = True) -> List[Dict]:
+    """Procesa documentos locales y, opcionalmente, archivos remotos de OneDrive.
+
+    Si ``save_to_disk`` es ``False`` los textos extraídos no se guardan en
+    ``output_folder`` y solo se devuelven en memoria.
+    """
+    if save_to_disk:
+        output_folder.mkdir(parents=True, exist_ok=True)
     input_folder.mkdir(parents=True, exist_ok=True)
 
     processed_docs = []
@@ -91,8 +96,9 @@ def process_documents(input_folder: Path, output_folder: Path) -> List[Dict]:
                     "source": f"OneDrive:{settings.ONEDRIVE_FOLDER}/{name}",
                     "onedrive_id": item_id,
                 }
-                with open(output_folder / f"{file_hash}.txt", "w", encoding="utf-8") as f_out:
-                    f_out.write(content)
+                if save_to_disk:
+                    with open(output_folder / f"{file_hash}.txt", "w", encoding="utf-8") as f_out:
+                        f_out.write(content)
                 processed_docs.append({"text": content, "metadata": metadata})
         except Exception as e:
             print(f"Error sincronizando OneDrive: {e}")
@@ -114,8 +120,9 @@ def process_documents(input_folder: Path, output_folder: Path) -> List[Dict]:
             }
 
 
-            with open(output_folder / f"{file_hash}.txt", "w", encoding="utf-8") as f_out:
-                f_out.write(content)
+            if save_to_disk:
+                with open(output_folder / f"{file_hash}.txt", "w", encoding="utf-8") as f_out:
+                    f_out.write(content)
 
             processed_docs.append({"text": content, "metadata": metadata})
 


### PR DESCRIPTION
## Summary
- allow processing OneDrive files without saving them locally
- expose save flag in ingestion scripts
- provide `.env.example` with all configurable variables
- document OneDrive setup and add a connectivity check script

## Testing
- `python -m py_compile src/ingestion/ingestor.py scripts/ingest_local_docs.py scripts/sync_and_index.py scripts/check_onedrive.py`
- `python scripts/check_onedrive.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_685e527c3cc88330a3adc8d222e7b077