### PR TITLE
Enable recursive ingestion from OneDrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@
   - `USE_ONEDRIVE` y `ENTRYPOINT_URL`
   - `USE_ONEDRIVE` es `false` por defecto; cámbialo a `true` para sincronizar documentos desde OneDrive
   - `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
-  - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento.
+  - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento y, opcionalmente, recorre subcarpetas con `recursive=True`.
   - Se añade un ejemplo de configuración en `*.env.example`.
   - Nuevo script `scripts/check_onedrive.py` para verificar la conectividad listando el contenido de la ruta configurada.
 

--- a/src/ingestion/ingestor.py
+++ b/src/ingestion/ingestor.py
@@ -83,6 +83,7 @@ def process_documents(input_folder: Path, output_folder: Path, save_to_disk: boo
             for name, item_id, modified, data in client.iter_files(
                 drive_id=settings.ONEDRIVE_DRIVE_ID,
                 folder_path=settings.ONEDRIVE_FOLDER,
+                recursive=True,
             ):
                 if Path(name).suffix.lower() not in SUPPORTED_EXTENSIONS:
                     continue


### PR DESCRIPTION
## Summary
- allow iterating over OneDrive subfolders in `iter_files`
- enable recursive document processing in `process_documents`
- document new `recursive` option in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685e73a039988330a44226855dd0e4d0