### PR TITLE
Add embedding device option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ WEAVIATE_API_KEY=
 USE_LOCAL_LLM=true
 LLM_MODEL_PATH=models/mistral-7b-instruct-v0.1.Q4_K_M.gguf
 LLM_MODEL_URL=http://localhost:8001
+# Embedding device (cpu or cuda)
+EMBEDDING_DEVICE=cpu
 
 # OneDrive settings
 ONEDRIVE_PATH=onedrive

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - División de los documentos en chunks usando `RecursiveCharacterTextSplitter`
     
 - Uso de embeddings locales con modelo `BAAI/bge-small-en-v1.5`
+- Para acelerar la generación de embeddings se puede configurar `EMBEDDING_DEVICE=cuda` en `.env`
     
 - Downgrade del cliente `weaviate-client` a versión 3.26.7 (por incompatibilidad con LangChain y cliente v4)
     

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -30,6 +30,8 @@ WEAVIATE_API_KEY = os.getenv("WEAVIATE_API_KEY")
 USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "true").lower() == "true"
 LLM_MODEL_PATH = Path(os.getenv("LLM_MODEL_PATH", BASE_DIR / "models" / "mistral-7b-instruct-v0.1.Q4_K_M.gguf"))
 LLM_MODEL_URL = os.getenv("LLM_MODEL_URL", "http://localhost:8001")
+# Dispositivo para generar los embeddings locales ("cpu" o "cuda")
+EMBEDDING_DEVICE = os.getenv("EMBEDDING_DEVICE", "cpu")
 
 # Ruta al directorio de OneDrive, donde se almacenarán los documentos legales
 # Este directorio se usa para sincronizar documentos desde OneDrive a la aplicación

--- a/src/vectorstore/embedder.py
+++ b/src/vectorstore/embedder.py
@@ -12,7 +12,8 @@ import os
 def get_local_embedder():
     """Devuelve un modelo de embedding local (BAAI/bge-small-en-v1.5)."""
     return HuggingFaceEmbeddings(
-        model_name="BAAI/bge-small-en-v1.5"
+        model_name="BAAI/bge-small-en-v1.5",
+        model_kwargs={"device": settings.EMBEDDING_DEVICE}
     )
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- make embedding device configurable via `EMBEDDING_DEVICE` setting
- allow `get_local_embedder()` to set the device for sentence-transformers
- document the option in `.env.example`
- mention GPU usage in the README

## Testing
- `python -m py_compile src/config/settings.py src/vectorstore/embedder.py`

------
https://chatgpt.com/codex/tasks/task_b_68622d7e9a088330a73d12921676ef7b