### PR TITLE
Enable recursive document ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
 - Creación de metadatos asociados: nombre de archivo, ruta, fecha
     
 - Script de ejecución: `scripts/ingest_local_docs.py`
-    
+- La lectura local ahora recorre `data/raw` y todas sus subcarpetas de forma
+  recursiva
+
 - Verificación de extracción correcta en entorno local
     
 

--- a/src/ingestion/ingestor.py
+++ b/src/ingestion/ingestor.py
@@ -104,8 +104,8 @@ def process_documents(input_folder: Path, output_folder: Path, save_to_disk: boo
         except Exception as e:
             print(f"Error sincronizando OneDrive: {e}")
 
-    for file in input_folder.iterdir():
-        if file.suffix.lower() not in SUPPORTED_EXTENSIONS:
+    for file in input_folder.rglob("*"):
+        if not file.is_file() or file.suffix.lower() not in SUPPORTED_EXTENSIONS:
             continue
 
         print(f"Procesando: {file.name}")


### PR DESCRIPTION
## Summary
- update `process_documents` to read files recursively
- document recursion behaviour in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68623ae1b4d08330a644939f001af4e2