### PR TITLE
Fix WeaviateClient keyword args

### DIFF
--- a/run.py
+++ b/run.py
@@ -46,7 +46,7 @@ def is_weaviate_running() -> bool:
 
 def wait_for_weaviate(url: str, timeout: int) -> None:
     """Espera hasta que Weaviate responda o se agote el tiempo."""
-    client = WeaviateClient(url)
+    client = WeaviateClient(url=url)
     start_time = time.time()
     while True:
         try:

--- a/scripts/delete_class.py
+++ b/scripts/delete_class.py
@@ -5,7 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from weaviate import WeaviateClient
 from src.config import settings
 
-client = WeaviateClient(settings.WEAVIATE_URL)
+client = WeaviateClient(url=settings.WEAVIATE_URL)
 
 CLASS_NAME = "LegalDocs"
 

--- a/scripts/show_classes.py
+++ b/scripts/show_classes.py
@@ -5,7 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from weaviate import WeaviateClient
 from src.config import settings
 
-client = WeaviateClient(settings.WEAVIATE_URL)
+client = WeaviateClient(url=settings.WEAVIATE_URL)
 classes = client.collections.list_all()
 
 print("\nClases encontradas en Weaviate:")


### PR DESCRIPTION
## Summary
- pass `url` keyword when creating `WeaviateClient`
- apply the same fix to helper scripts

## Testing
- `python -m py_compile run.py scripts/delete_class.py scripts/show_classes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68624c06c5188330a311d1a21ef13a3e