### PR TITLE
Add chunk tracking to sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@
         
     - Vuelve a trocear y reindexar solo lo nuevo
         
- - Control mediante archivo `.processed_files.json`
+ - Control mediante archivo `.processed_files.json` (ahora registra el hash del
+   documento y si ha sido troceado e indexado para evitar reprocesos)
  - Parametrización por `--gpt_id` para clasificar por GPT
  - Se calcula un hash por archivo para detectar cambios y evitar reindexados innecesarios
  - Listo para ejecución manual o futura automatización por `cron` / `Task Scheduler`


### PR DESCRIPTION
## Summary
- track processed documents including chunk/index status
- skip documents already chunked and indexed in `sync_and_index`
- document tracker behaviour in README

## Testing
- `python -m py_compile scripts/sync_and_index.py`

------
https://chatgpt.com/codex/tasks/task_b_68637bb32da08330af5c85e7be46b8b2