### PR TITLE
Optimize sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@
   - `USE_ONEDRIVE` y `ENTRYPOINT_URL`
   - `USE_ONEDRIVE` es `false` por defecto; cámbialo a `true` para sincronizar documentos desde OneDrive
   - `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
+  - Además acepta un parámetro opcional `tracker` para omitir los ficheros locales ya procesados y evitar leerlos de nuevo.
   - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento y, opcionalmente, recorre subcarpetas con `recursive=True`.
   - Se añade un ejemplo de configuración en `*.env.example`.
   - Nuevo script `scripts/check_onedrive.py` para verificar la conectividad listando el contenido de la ruta configurada.

--- a/scripts/sync_and_index.py
+++ b/scripts/sync_and_index.py
@@ -53,6 +53,7 @@ def sync_and_index(gpt_id: str):
         input_path,
         output_path,
         save_to_disk=True,
+        tracker=tracker,
     )
 
     # Filtrar aquellos que aún no han sido chunkificados o cuyo contenido cambió


### PR DESCRIPTION
## Summary
- allow `ingestor.process_documents` to skip files via a tracker
- wire tracker into `sync_and_index`
- document new tracker parameter

## Testing
- `python -m py_compile scripts/sync_and_index.py src/ingestion/ingestor.py scripts/ingest_local_docs.py`

------
https://chatgpt.com/codex/tasks/task_b_6863ad5612548330bf7b351317283754