### PR TITLE
Add skipping of processed OneDrive files

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
   - `USE_ONEDRIVE` es `false` por defecto; cámbialo a `true` para sincronizar documentos desde OneDrive
   - `process_documents` ahora, si `USE_ONEDRIVE=true`, lee los archivos directamente desde OneDrive sin guardarlos en `data/raw` y genera los chunks en `data/chunks`.
   - Además acepta un parámetro opcional `tracker` para omitir los ficheros locales ya procesados y evitar leerlos de nuevo.
+  - El mismo `tracker` se emplea ahora para ignorar los documentos de OneDrive previamente procesados basándose en su nombre.
   - Para usar esta modalidad remota se debe configurar el `.env` con las credenciales anteriores. El cliente cuenta con un método `iter_files()` que devuelve `(nombre, id, modificado, bytes)` para cada documento y, opcionalmente, recorre subcarpetas con `recursive=True`.
   - Se añade un ejemplo de configuración en `*.env.example`.
   - Nuevo script `scripts/check_onedrive.py` para verificar la conectividad listando el contenido de la ruta configurada.

--- a/src/ingestion/ingestor.py
+++ b/src/ingestion/ingestor.py
@@ -94,6 +94,14 @@ def process_documents(
             ):
                 if Path(name).suffix.lower() not in SUPPORTED_EXTENSIONS:
                     continue
+
+                source = f"OneDrive:{settings.ONEDRIVE_FOLDER}/{name}"
+                if tracker:
+                    entry = tracker.get(source)
+                    if entry and entry.get("chunked") and entry.get("indexed"):
+                        # Documento remoto ya procesado por completo
+                        continue
+
                 print(f"Procesando remoto: {name}")
                 content = extract_text_from_bytes(name, data)
                 file_hash = compute_hash(data)
@@ -101,7 +109,7 @@ def process_documents(
                     "doc_id": file_hash,
                     "filename": name,
                     "created": modified or datetime.datetime.now().isoformat(),
-                    "source": f"OneDrive:{settings.ONEDRIVE_FOLDER}/{name}",
+                    "source": source,
                     "onedrive_id": item_id,
                 }
                 if save_to_disk:


### PR DESCRIPTION
## Summary
- skip remote OneDrive docs if marked as chunked and indexed
- document new behavior in README

## Testing
- `python -m py_compile src/ingestion/ingestor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863b9cfea0c833087bf2cc8884ae130