### PR TITLE
Add watchdog systemd units

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,13 @@
 - Actualización de utilidades (`delete_class.py`, `list_embeddings.py`, `show_classes.py`) para listar y gestionar colecciones con la nueva sintaxis.
 
 
+### **FASE 16: Supervisión automática de servicios**
+
+- Se añaden archivos `services/rag_watchdog.service` y `services/rag_watchdog.timer` para monitorizar la API y Weaviate.
+- Para activarlo en sistemas con `systemd`:
+  ```bash
+  sudo systemctl enable --now rag_watchdog.timer
+  ```
 ---
 
 ### **PENDIENTE ACTUAL**

--- a/services/rag_watchdog.service
+++ b/services/rag_watchdog.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor and restart RAG API and Weaviate
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /home/consistorioai/RAG_Asistente/watch_services.sh
+Restart=always
+RestartSec=30
+

--- a/services/rag_watchdog.timer
+++ b/services/rag_watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic check of RAG services
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+


### PR DESCRIPTION
## Summary
- add rag_watchdog.service and rag_watchdog.timer systemd units under `services/`
- document enabling the timer in README

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6866477d805c83308f245ec7f4b576a6