### PR TITLE
Use multilingual MiniLM embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 - División de los documentos en chunks usando `RecursiveCharacterTextSplitter`
     
-- Uso de embeddings locales con modelo `BAAI/bge-small-en-v1.5`
+- Uso de embeddings locales con modelo `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
 - Para acelerar la generación de embeddings se puede configurar `EMBEDDING_DEVICE=cuda` y ajustar `BATCH_SIZE` en `.env`
 
 - Weaviate connection (probado con weaviate-client v4.x)

--- a/src/rag_logic/retriever_module.py
+++ b/src/rag_logic/retriever_module.py
@@ -56,7 +56,7 @@ def get_weaviate_client():
 @lru_cache(maxsize=1)
 def _get_embedder():
     return HuggingFaceEmbeddings(
-        model_name="BAAI/bge-small-en-v1.5",
+        model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
         encode_kwargs={"batch_size": settings.BATCH_SIZE},
     )
 

--- a/src/vectorstore/embedder.py
+++ b/src/vectorstore/embedder.py
@@ -17,7 +17,7 @@ _GRPC_PORT = 50051
 # ── embeddings ────────────────────
 def get_local_embedder():
     return HuggingFaceEmbeddings(
-        model_name="BAAI/bge-small-en-v1.5",
+        model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
         model_kwargs={"device": settings.EMBEDDING_DEVICE},
         encode_kwargs={"batch_size": settings.BATCH_SIZE},
     )


### PR DESCRIPTION
## Summary
- switch embedder model to `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
- update retriever to use the same embedder
- note new model in README

## Testing
- `python -m py_compile src/vectorstore/embedder.py src/rag_logic/retriever_module.py`


------
https://chatgpt.com/codex/tasks/task_b_686d9ce4de948330beff4a02cee6c61d