### PR TITLE
Add script usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,22 @@
   ```
 ---
 
+### **FASE 17: Scripts de arranque y vigilancia**
+
+- `start_server.sh` inicia la API en segundo plano y guarda los mensajes en `rag_api.log`.
+  ```bash
+  bash start_server.sh
+  ```
+- `stop_api.sh` detiene de forma limpia cualquier proceso `run.py` que esté en ejecución.
+  ```bash
+  bash stop_api.sh
+  ```
+- `watch_services.sh` comprueba periódicamente que Weaviate y la API sigan activos y los reinicie si se detienen.
+  ```bash
+  bash watch_services.sh
+  ```
+  Estos scripts pueden programarse mediante `cron` o integrarse con `systemd` para supervisión automática.
+
 ### **PENDIENTE ACTUAL**
 
 -  Validar resultados tras nueva indexación con consulta ejemplo


### PR DESCRIPTION
## Summary
- document start_server.sh, stop_api.sh and watch_services.sh
- add basic usage examples and mention cron/systemd scheduling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6878a67f6f408330a15f999f8752e90f