### PR TITLE
Update README with monitoring and volume notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 - Automatización:
 
     - Nuevo `run.py` inicia Weaviate con Docker Compose y arranca la API. Ejecutar `python run.py` para poner ambos servicios en marcha.
+    - En `docker-compose.yml` hay líneas comentadas para usar un volumen persistente de Docker (`legaldocs_v2`). Descoméntalas si prefieres un volumen en lugar del *bind mount* por defecto.
         
 - Validación de la función `queryLegal` desde GPT personalizado
     
@@ -287,6 +288,7 @@
 ### **FASE 16: Supervisión automática de servicios**
 
 - Se añaden archivos `services/rag_watchdog.service` y `services/rag_watchdog.timer` para monitorizar la API y Weaviate.
+- Se incluye el script `watch_services.sh`, que puede ejecutarse solo o en conjunto con el servicio y su *timer* para una vigilancia continua.
 - Para activarlo en sistemas con `systemd`:
   ```bash
   sudo systemctl enable --now rag_watchdog.timer


### PR DESCRIPTION
## Summary
- reference optional Docker volume usage in README
- mention `watch_services.sh` usage with `rag_watchdog` service

## Testing
- `python -m compileall -q src scripts run.py pruebaAPIWEAV.py watch_services.sh`

------
https://chatgpt.com/codex/tasks/task_b_6878a681cd988330b48686a02cc464b2