### PR TITLE
Configure rotating API logs

### DIFF
--- a/scripts/start_api.py
+++ b/scripts/start_api.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+import logging
+from logging.config import dictConfig
 
 # 1️⃣  AÑADIR LA RAÍZ **ANTES** DE CUALQUIER IMPORT DE `src`
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -13,6 +15,31 @@ sys.path.append(str(PROJECT_ROOT))
 from src.config import settings  # noqa: E402  ← ahora sí funciona
 
 import uvicorn  # noqa: E402  (se importa después para mantener orden lógico)
+
+# Configuración de logging para que cada entrada incluya fecha y hora
+LOG_FORMAT = "%(asctime)s %(levelname)s:     %(message)s"
+LOGGING_CONFIG = {
+    "version": 1,
+    "formatters": {
+        "default": {"format": LOG_FORMAT},
+        "access": {"format": LOG_FORMAT},
+    },
+    "handlers": {
+        "default": {"class": "logging.StreamHandler", "formatter": "default"},
+        "access": {"class": "logging.StreamHandler", "formatter": "access"},
+    },
+    "loggers": {
+        "": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.access": {
+            "handlers": ["access"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
+dictConfig(LOGGING_CONFIG)
 
 if __name__ == "__main__":
     # No usar reload en Windows, rompe multiprocessing + imports
@@ -24,4 +51,5 @@ if __name__ == "__main__":
         port=port,
         reload=False,
         workers=workers,
+        log_config=LOGGING_CONFIG,
     )

--- a/start_server.sh
+++ b/start_server.sh
@@ -3,7 +3,12 @@
 # Ruta absoluta del proyecto (ajústalo si es necesario)
 PROJECT_DIR="/home/consistorioai/RAG_Asistente"
 VENV_PATH="$PROJECT_DIR/venv/bin/activate"
-LOG_FILE="$PROJECT_DIR/rag_api.log"
+
+# Directorio donde se almacenarán los logs rotados por fecha
+LOG_DIR="/home/consistorioai/logs"
+mkdir -p "$LOG_DIR"
+# Nombre del log actual basado en la fecha
+LOG_FILE="$LOG_DIR/rag_api_$(date +%F).log"
 
 # Entra al directorio del proyecto
 cd "$PROJECT_DIR" || exit 1

--- a/watch_services.sh
+++ b/watch_services.sh
@@ -8,7 +8,12 @@
 
 PROJECT_DIR="/home/consistorioai/RAG_Asistente"
 VENV_PATH="$PROJECT_DIR/venv/bin/activate"
-LOG_FILE="$PROJECT_DIR/rag_api.log"
+
+# Directorio donde se almacenarán los logs rotados por fecha
+LOG_DIR="/home/consistorioai/logs"
+mkdir -p "$LOG_DIR"
+# Nombre del log actual basado en la fecha
+LOG_FILE="$LOG_DIR/rag_api_$(date +%F).log"
 
 cd "$PROJECT_DIR" || exit 1
 


### PR DESCRIPTION
## Summary
- log to `/home/consistorioai/logs` with daily rotation
- ensure watch script and start script use dated log files
- show timestamps in API output via logging config

## Testing
- `bash -n start_server.sh`
- `bash -n watch_services.sh`
- `python -m py_compile scripts/start_api.py`


------
https://chatgpt.com/codex/tasks/task_b_687f3ce7f2bc8330828ba4478461721d