### PR TITLE
Add economic and procedural GPT profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@
 
 - Simulación de estructura futura para múltiples GPTs (`legal`, `laboral`, etc.)
 
-- Se añaden los perfiles `contratacion` y `consultor`, cada uno con su propia
-  colección en Weaviate y prompt especializado.
+- Se añaden los perfiles `contratacion`, `consultor`, `economico` y `procesal`,
+  cada uno con su propia colección en Weaviate y prompt especializado.
     
 
 ---
@@ -233,6 +233,8 @@
     python scripts/sync_and_index.py --gpt_id default
     python scripts/sync_and_index.py --gpt_id contratacion
     python scripts/sync_and_index.py --gpt_id consultor
+    python scripts/sync_and_index.py --gpt_id economico
+    python scripts/sync_and_index.py --gpt_id procesal
     ```
     
 - Confirmación de regeneración exitosa con chunks más cortos y mejor distribuidos

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -42,7 +42,7 @@ components:
         gpt_id:
           type: string
           description: Identificador opcional del GPT
-          enum: [default, contratacion, consultor]
+          enum: [default, contratacion, consultor, economico, procesal]
         question:
           type: string
           description: Pregunta legal a responder

--- a/src/config/gpt_profiles.py
+++ b/src/config/gpt_profiles.py
@@ -45,11 +45,11 @@ Respuesta:
     },
 
 
-"consultor": {
-    "collection": "LegalDocs_consultor",
-    "prompt": PromptTemplate(
-        input_variables=["context", "question"],
-        template="""
+    "consultor": {
+        "collection": "LegalDocs_consultor",
+        "prompt": PromptTemplate(
+            input_variables=["context", "question"],
+            template="""
 Eres un consultor jurídico experto en derecho administrativo español, especializado en análisis de jurisprudencia de tribunales superiores (TS, TSJ, TJUE).
 
 Responde únicamente utilizando el contexto proporcionado. No inventes, no rellenes huecos y no generalices sin base.
@@ -85,6 +85,43 @@ Pregunta:
 
 Respuesta:
 """
-    )
-},
+        )
+    },
+
+    "economico": {
+        "collection": "LegalDocs_economico",
+        "prompt": PromptTemplate(
+            input_variables=["context", "question"],
+            template="""
+Actúa como asesor experto en fiscalización y control económico del sector público, con especial atención a la doctrina del Tribunal de Cuentas. Responde de forma jurídica y precisa utilizando únicamente la información proporcionada.
+
+Contexto:
+{context}
+
+Pregunta:
+{question}
+
+Respuesta:
+"""
+        )
+    },
+
+    "procesal": {
+        "collection": "LegalDocs_procesal",
+        "prompt": PromptTemplate(
+            input_variables=["context", "question"],
+            template="""
+Eres un consultor especializado en derecho procesal y jurisprudencia del Tribunal Supremo. Utiliza solo el contexto proporcionado y cita el ROJ o ECLI si está disponible.
+
+Contexto:
+{context}
+
+Pregunta:
+{question}
+
+Respuesta:
+"""
+        )
+    },
 }
+

--- a/src/rag_logic/generator.py
+++ b/src/rag_logic/generator.py
@@ -102,8 +102,8 @@ def get_rag_chain(gpt_id: str = "default", k: int = settings.RETRIEVER_K):
         # ✅ Filtrado y priorización avanzada
         docs = filter_docs_by_token_limit(docs, question, max_tokens=settings.MAX_CONTEXT_TOKENS)
 
-        # 👉 Añadir nombre del documento al contexto SOLO si es perfil consultor
-        if gpt_id == "consultor":
+        # 👉 Añadir nombre del documento al contexto si el perfil lo requiere
+        if gpt_id in {"consultor", "procesal"}:
             for doc in docs:
                 filename = doc.metadata.get("filename") or doc.metadata.get("source") or "documento_desconocido"
                 header = f"[Documento fuente: {filename.replace('.pdf', '')}]\n"


### PR DESCRIPTION
## Summary
- define new GPT profiles `economico` and `procesal`
- include them in retrieval logic for document headers
- document new profiles in README and OpenAPI schema

## Testing
- `python -m py_compile src/config/gpt_profiles.py src/rag_logic/generator.py`

------
https://chatgpt.com/codex/tasks/task_b_6881fd6f75d48330bbc7c362b1d3d890